### PR TITLE
chore : build.gradle queryDSL 설정 변경 (#21)

### DIFF
--- a/needeachother/build.gradle
+++ b/needeachother/build.gradle
@@ -2,10 +2,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.2'
-
-	// queryDSL
-	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
-
 }
 
 group = 'com.neo'
@@ -25,7 +21,6 @@ configurations {
 		extendsFrom annotationProcessor
 	}
 }
-
 
 dependencies {
 
@@ -53,10 +48,11 @@ dependencies {
 
 	// Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	implementation "com.querydsl:querydsl-core"
+
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
 
 	// mysql driver
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -74,19 +70,15 @@ tasks.named('test') {
 
 targetCompatibility = JavaVersion.VERSION_17
 
-// queryDSL 추가 : QueryDSL 빌드 옵션
-def querydslDir = "$buildDir/generated/querydsl"
+// clean 태스크와 cleanGeneatedDir 태스크 중 취향에 따라서 선택하세요.
+/** clean 태스크 실행시 QClass 삭제 */
+clean {
+	delete file('src/main/generated') // 인텔리제이 Annotation processor 생성물 생성위치
+}
 
-querydsl {
-	jpa = true
-	querydslSourcesDir = querydslDir
-}
-sourceSets {
-	main.java.srcDir querydslDir
-}
-configurations {
-	querydsl.extendsFrom compileClasspath
-}
-compileQuerydsl {
-	options.annotationProcessorPath = configurations.querydsl
+/**
+ * 인텔리제이 Annotation processor 에 생성되는 'src/main/generated' 디렉터리 삭제
+ */
+task cleanGeneatedDir(type: Delete) { // 인텔리제이 annotation processor 가 생성한 Q클래스가 clean 태스크로 삭제되는 게 불편하다면 둘 중에 하나를 선택
+	delete file('src/main/generated')
 }

--- a/needeachother/src/main/generated/com/neo/needeachother/common/entity/QNEOTimeDefaultEntity.java
+++ b/needeachother/src/main/generated/com/neo/needeachother/common/entity/QNEOTimeDefaultEntity.java
@@ -1,0 +1,39 @@
+package com.neo.needeachother.common.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QNEOTimeDefaultEntity is a Querydsl query type for NEOTimeDefaultEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QNEOTimeDefaultEntity extends EntityPathBase<NEOTimeDefaultEntity> {
+
+    private static final long serialVersionUID = -1202157345L;
+
+    public static final QNEOTimeDefaultEntity nEOTimeDefaultEntity = new QNEOTimeDefaultEntity("nEOTimeDefaultEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QNEOTimeDefaultEntity(String variable) {
+        super(NEOTimeDefaultEntity.class, forVariable(variable));
+    }
+
+    public QNEOTimeDefaultEntity(Path<? extends NEOTimeDefaultEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNEOTimeDefaultEntity(PathMetadata metadata) {
+        super(NEOTimeDefaultEntity.class, metadata);
+    }
+
+}
+

--- a/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOFanEntity.java
+++ b/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOFanEntity.java
@@ -1,0 +1,73 @@
+package com.neo.needeachother.users.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QNEOFanEntity is a Querydsl query type for NEOFanEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNEOFanEntity extends EntityPathBase<NEOFanEntity> {
+
+    private static final long serialVersionUID = -2127163797L;
+
+    public static final QNEOFanEntity nEOFanEntity = new QNEOFanEntity("nEOFanEntity");
+
+    public final QNEOUserEntity _super = new QNEOUserEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath email = _super.email;
+
+    //inherited
+    public final EnumPath<com.neo.needeachother.users.enums.NEOGenderType> gender = _super.gender;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final StringPath neoNickName = _super.neoNickName;
+
+    //inherited
+    public final StringPath phoneNumber = _super.phoneNumber;
+
+    //inherited
+    public final StringPath providerType = _super.providerType;
+
+    //inherited
+    public final ListPath<NEOUserRelationEntity, QNEOUserRelationEntity> subscribedStarList = _super.subscribedStarList;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath userID = _super.userID;
+
+    //inherited
+    public final StringPath userName = _super.userName;
+
+    //inherited
+    public final StringPath userPW = _super.userPW;
+
+    public QNEOFanEntity(String variable) {
+        super(NEOFanEntity.class, forVariable(variable));
+    }
+
+    public QNEOFanEntity(Path<? extends NEOFanEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNEOFanEntity(PathMetadata metadata) {
+        super(NEOFanEntity.class, metadata);
+    }
+
+}
+

--- a/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOStarEntity.java
+++ b/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOStarEntity.java
@@ -1,0 +1,80 @@
+package com.neo.needeachother.users.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNEOStarEntity is a Querydsl query type for NEOStarEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNEOStarEntity extends EntityPathBase<NEOStarEntity> {
+
+    private static final long serialVersionUID = -836930080L;
+
+    public static final QNEOStarEntity nEOStarEntity = new QNEOStarEntity("nEOStarEntity");
+
+    public final QNEOUserEntity _super = new QNEOUserEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath email = _super.email;
+
+    public final ListPath<NEOUserRelationEntity, QNEOUserRelationEntity> followerList = this.<NEOUserRelationEntity, QNEOUserRelationEntity>createList("followerList", NEOUserRelationEntity.class, QNEOUserRelationEntity.class, PathInits.DIRECT2);
+
+    //inherited
+    public final EnumPath<com.neo.needeachother.users.enums.NEOGenderType> gender = _super.gender;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    //inherited
+    public final StringPath neoNickName = _super.neoNickName;
+
+    //inherited
+    public final StringPath phoneNumber = _super.phoneNumber;
+
+    //inherited
+    public final StringPath providerType = _super.providerType;
+
+    public final StringPath starNickName = createString("starNickName");
+
+    public final ListPath<NEOStarTypeEntity, QNEOStarTypeEntity> starTypeList = this.<NEOStarTypeEntity, QNEOStarTypeEntity>createList("starTypeList", NEOStarTypeEntity.class, QNEOStarTypeEntity.class, PathInits.DIRECT2);
+
+    //inherited
+    public final ListPath<NEOUserRelationEntity, QNEOUserRelationEntity> subscribedStarList = _super.subscribedStarList;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath userID = _super.userID;
+
+    //inherited
+    public final StringPath userName = _super.userName;
+
+    //inherited
+    public final StringPath userPW = _super.userPW;
+
+    public QNEOStarEntity(String variable) {
+        super(NEOStarEntity.class, forVariable(variable));
+    }
+
+    public QNEOStarEntity(Path<? extends NEOStarEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNEOStarEntity(PathMetadata metadata) {
+        super(NEOStarEntity.class, metadata);
+    }
+
+}
+

--- a/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOStarTypeEntity.java
+++ b/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOStarTypeEntity.java
@@ -1,0 +1,53 @@
+package com.neo.needeachother.users.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNEOStarTypeEntity is a Querydsl query type for NEOStarTypeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNEOStarTypeEntity extends EntityPathBase<NEOStarTypeEntity> {
+
+    private static final long serialVersionUID = -533211334L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNEOStarTypeEntity nEOStarTypeEntity = new QNEOStarTypeEntity("nEOStarTypeEntity");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QNEOStarEntity neoStar;
+
+    public final EnumPath<com.neo.needeachother.users.enums.NEOStarDetailClassification> starType = createEnum("starType", com.neo.needeachother.users.enums.NEOStarDetailClassification.class);
+
+    public QNEOStarTypeEntity(String variable) {
+        this(NEOStarTypeEntity.class, forVariable(variable), INITS);
+    }
+
+    public QNEOStarTypeEntity(Path<? extends NEOStarTypeEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNEOStarTypeEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNEOStarTypeEntity(PathMetadata metadata, PathInits inits) {
+        this(NEOStarTypeEntity.class, metadata, inits);
+    }
+
+    public QNEOStarTypeEntity(Class<? extends NEOStarTypeEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.neoStar = inits.isInitialized("neoStar") ? new QNEOStarEntity(forProperty("neoStar")) : null;
+    }
+
+}
+

--- a/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOUserEntity.java
+++ b/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOUserEntity.java
@@ -1,0 +1,64 @@
+package com.neo.needeachother.users.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNEOUserEntity is a Querydsl query type for NEOUserEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNEOUserEntity extends EntityPathBase<NEOUserEntity> {
+
+    private static final long serialVersionUID = -1041195879L;
+
+    public static final QNEOUserEntity nEOUserEntity = new QNEOUserEntity("nEOUserEntity");
+
+    public final com.neo.needeachother.common.entity.QNEOTimeDefaultEntity _super = new com.neo.needeachother.common.entity.QNEOTimeDefaultEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath email = createString("email");
+
+    public final EnumPath<com.neo.needeachother.users.enums.NEOGenderType> gender = createEnum("gender", com.neo.needeachother.users.enums.NEOGenderType.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath neoNickName = createString("neoNickName");
+
+    public final StringPath phoneNumber = createString("phoneNumber");
+
+    public final StringPath providerType = createString("providerType");
+
+    public final ListPath<NEOUserRelationEntity, QNEOUserRelationEntity> subscribedStarList = this.<NEOUserRelationEntity, QNEOUserRelationEntity>createList("subscribedStarList", NEOUserRelationEntity.class, QNEOUserRelationEntity.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final StringPath userID = createString("userID");
+
+    public final StringPath userName = createString("userName");
+
+    public final StringPath userPW = createString("userPW");
+
+    public QNEOUserEntity(String variable) {
+        super(NEOUserEntity.class, forVariable(variable));
+    }
+
+    public QNEOUserEntity(Path<? extends NEOUserEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNEOUserEntity(PathMetadata metadata) {
+        super(NEOUserEntity.class, metadata);
+    }
+
+}
+

--- a/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOUserRelationEntity.java
+++ b/needeachother/src/main/generated/com/neo/needeachother/users/entity/QNEOUserRelationEntity.java
@@ -1,0 +1,54 @@
+package com.neo.needeachother.users.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNEOUserRelationEntity is a Querydsl query type for NEOUserRelationEntity
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNEOUserRelationEntity extends EntityPathBase<NEOUserRelationEntity> {
+
+    private static final long serialVersionUID = 1354497973L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNEOUserRelationEntity nEOUserRelationEntity = new QNEOUserRelationEntity("nEOUserRelationEntity");
+
+    public final QNEOStarEntity followee;
+
+    public final QNEOUserEntity follower;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QNEOUserRelationEntity(String variable) {
+        this(NEOUserRelationEntity.class, forVariable(variable), INITS);
+    }
+
+    public QNEOUserRelationEntity(Path<? extends NEOUserRelationEntity> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNEOUserRelationEntity(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNEOUserRelationEntity(PathMetadata metadata, PathInits inits) {
+        this(NEOUserRelationEntity.class, metadata, inits);
+    }
+
+    public QNEOUserRelationEntity(Class<? extends NEOUserRelationEntity> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.followee = inits.isInitialized("followee") ? new QNEOStarEntity(forProperty("followee")) : null;
+        this.follower = inits.isInitialized("follower") ? new QNEOUserEntity(forProperty("follower")) : null;
+    }
+
+}
+


### PR DESCRIPTION
## 추가한 기능 설명
build.gradle의 queryDSL 설정을 변경했습니다.

```
plugins {
	id 'java'
	id 'org.springframework.boot' version '3.1.2'
	id 'io.spring.dependency-management' version '1.1.2'
}

group = 'com.neo'
version = '0.0.1-SNAPSHOT'

java {
	sourceCompatibility = "17"
}

repositories {
	mavenCentral()
}

// add
configurations {
	compileOnly {
		extendsFrom annotationProcessor
	}
}

dependencies {

	// related spring web
	implementation 'org.springframework.boot:spring-boot-starter-web'
	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
	implementation 'org.springframework.boot:spring-boot-starter-validation'


	// security & oauth
	// implementation 'org.springframework.boot:spring-boot-starter-security'

	// related with RDB & NoSQL & Cache
	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
	implementation 'org.springframework.boot:spring-boot-starter-data-redis'


	// lombok library
	implementation 'org.projectlombok:lombok:1.18.26'
	annotationProcessor 'org.projectlombok:lombok:1.18.26'

	// swagger implement
	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

	// Querydsl 추가
	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
	implementation "com.querydsl:querydsl-core"

	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
	annotationProcessor "jakarta.persistence:jakarta.persistence-api"

	// mysql driver
	runtimeOnly 'com.mysql:mysql-connector-j'


	// for test
	testImplementation 'org.springframework.boot:spring-boot-starter-test'
	testImplementation 'org.springframework.security:spring-security-test'
}


tasks.named('test') {
	useJUnitPlatform()
}

targetCompatibility = JavaVersion.VERSION_17

// clean 태스크와 cleanGeneatedDir 태스크 중 취향에 따라서 선택하세요.
/** clean 태스크 실행시 QClass 삭제 */
clean {
	delete file('src/main/generated') // 인텔리제이 Annotation processor 생성물 생성위치
}

/**
 * 인텔리제이 Annotation processor 에 생성되는 'src/main/generated' 디렉터리 삭제
 */
task cleanGeneatedDir(type: Delete) { // 인텔리제이 annotation processor 가 생성한 Q클래스가 clean 태스크로 삭제되는 게 불편하다면 둘 중에 하나를 선택
	delete file('src/main/generated')
}
```

변화점 : 
- id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" 제거 (구 버전 인텔리제이 사용 + 신 버전 인텔리제이 사용법을 동시에 사용하고 있었던 점 제거.)
- implementation "com.querydsl:querydsl-core" 삽입
- 기타 경로설정 등의 코드 제거
- Q파일 삭제 작업 코드 생성

<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
